### PR TITLE
Added multi result support to action handlers

### DIFF
--- a/app/src/menus/actions/_tests/Action.ts
+++ b/app/src/menus/actions/_tests/Action.ts
@@ -1,4 +1,4 @@
-import {Action} from "../Action";
+import {Action, results, sources} from "../Action";
 import {IAction} from "../_types/IAction";
 import {IActionBinding} from "../_types/IActionBinding";
 import {IMenuItem} from "../../items/_types/IMenuItem";
@@ -40,40 +40,7 @@ describe("Action", () => {
             const binding = action.createBinding(2);
             expect(binding.action).toEqual(action);
             expect(binding.data).toEqual(2);
-            expect(binding.tags).toEqual([]);
-
-            const binding2 = action.createBinding(12, ["hoi", "hi"]);
-            expect(binding2.action).toEqual(action);
-            expect(binding2.data).toEqual(12);
-            expect(binding2.tags).toEqual(["hoi", "hi"]);
-        });
-        it("Inherits bindings from the action", () => {
-            const action = new Action(
-                (input: number[]) => {
-                    return 3;
-                },
-                ["potatoes"]
-            );
-            const binding = action.createBinding(2);
-            expect(binding.tags).toEqual(["potatoes"]);
-
-            const binding2 = action.createBinding(2, ["oranges"]);
-            expect(binding2.tags).toEqual(["oranges"]);
-
-            const binding3 = action.createBinding(2, tags => [...tags, "oranges"]);
-            expect(binding3.tags).toEqual(["potatoes", "oranges"]);
-        });
-    });
-    describe("Action.createBinding", () => {
-        // Notice that these action cores are only for testing and don't make any sense
-        it("Creates a binding to this action", () => {
-            const action = new Action((input: number[]) => {
-                return 3;
-            });
-            const binding = action.createBinding(2);
-            expect(binding.action).toEqual(action);
-            expect(binding.data).toEqual(2);
-            expect(binding.tags).toEqual([]);
+            expect(binding.tags).toEqual(["context"]);
 
             const binding2 = action.createBinding(12, ["hoi", "hi"]);
             expect(binding2.action).toEqual(action);
@@ -205,51 +172,125 @@ describe("Action", () => {
                     ])
                 ).toBe(12);
             });
-            it("Properly works for sub handlers", () => {
-                const stringLengthHandler = action.createHandler((inputs: string[]) => {
-                    return inputs.reduce((cur, text) => cur + text.length, 0) + 1;
-                });
-                const boolStringLengthSubHandler = stringLengthHandler.createHandler(
-                    (inputs: boolean[]) => {
-                        return inputs.reduce((cur, bool) => cur + bool, "yes"); // casts boolean to "true" or "false" and adds all values to one string, starting with "yes"
-                    }
-                );
-                expect(
-                    action.get([
-                        createItem(stringLengthHandler.createBinding("yes")),
-                        createItem(action.createBinding(2)),
-                        createItem(boolStringLengthSubHandler.createBinding(false)),
-                        createItem(action.createBinding(4)),
-                        createItem(stringLengthHandler.createBinding("no")),
-                        createItem(boolStringLengthSubHandler.createBinding(true)),
-                        createItem(),
-                    ])
-                ).toBe(24);
+            describe("Properly works for sub handlers", () => {
+                it("Correctly works for handlers returning 1 result", () => {
+                    const stringLengthHandler = action.createHandler(
+                        (inputs: string[]) => {
+                            return inputs.reduce((cur, text) => cur + text.length, 0) + 1;
+                        }
+                    );
+                    const boolStringLengthSubHandler = stringLengthHandler.createHandler(
+                        (inputs: boolean[]) => {
+                            return inputs.reduce((cur, bool) => cur + bool, "yes"); // casts boolean to "true" or "false" and adds all values to one string, starting with "yes"
+                        }
+                    );
+                    expect(
+                        action.get([
+                            createItem(stringLengthHandler.createBinding("yes")),
+                            createItem(action.createBinding(2)),
+                            createItem(boolStringLengthSubHandler.createBinding(false)),
+                            createItem(action.createBinding(4)),
+                            createItem(stringLengthHandler.createBinding("no")),
+                            createItem(boolStringLengthSubHandler.createBinding(true)),
+                            createItem(),
+                        ])
+                    ).toBe(24);
 
-                // Even more extensive/elaborate test
-                const mulHandler = action.createHandler((inputs: number[]) =>
-                    inputs.reduce((cur, data) => cur * data, 1)
-                );
-                const mul2SubHandler = mulHandler.createHandler((inputs: number[]) =>
-                    inputs.reduce((cur, data) => cur + 2 * data, 0)
-                );
-                const mul3SubHandler = mulHandler.createHandler((inputs: number[]) =>
-                    inputs.reduce((cur, data) => cur + 3 * data, 0)
-                );
-                expect(
-                    action.get([
-                        createItem(stringLengthHandler.createBinding("yes")),
+                    // Even more extensive/elaborate test
+                    const mulHandler = action.createHandler((inputs: number[]) =>
+                        inputs.reduce((cur, data) => cur * data, 1)
+                    );
+                    const mul2SubHandler = mulHandler.createHandler((inputs: number[]) =>
+                        inputs.reduce((cur, data) => cur + 2 * data, 0)
+                    );
+                    const mul3SubHandler = mulHandler.createHandler((inputs: number[]) =>
+                        inputs.reduce((cur, data) => cur + 3 * data, 0)
+                    );
+                    expect(
+                        action.get([
+                            createItem(stringLengthHandler.createBinding("yes")),
+                            createItem(action.createBinding(2)),
+                            createItem(boolStringLengthSubHandler.createBinding(false)),
+                            createItem(action.createBinding(4)),
+                            createItem(stringLengthHandler.createBinding("no")),
+                            createItem(boolStringLengthSubHandler.createBinding(true)),
+                            createItem(),
+                            // (2 * 2) * (3 * 5)
+                            createItem(mul2SubHandler.createBinding(2)),
+                            createItem(mul3SubHandler.createBinding(5)),
+                        ])
+                    ).toBe(84);
+                });
+                describe("Correctly works for handlers returning results symbol", () => {
+                    const createItems = (handler: IAction<string, any>) => [
+                        createItem(handler.createBinding("yes")),
                         createItem(action.createBinding(2)),
-                        createItem(boolStringLengthSubHandler.createBinding(false)),
-                        createItem(action.createBinding(4)),
-                        createItem(stringLengthHandler.createBinding("no")),
-                        createItem(boolStringLengthSubHandler.createBinding(true)),
+                        createItem(handler.createBinding("oranges")),
+                        createItem(handler.createBinding("yes")),
                         createItem(),
-                        // (2 * 2) * (3 * 5)
-                        createItem(mul2SubHandler.createBinding(2)),
-                        createItem(mul3SubHandler.createBinding(5)),
-                    ])
-                ).toBe(84);
+                    ];
+                    it("Works without sources if purely mapping", () => {
+                        const stringLengthHandler = action.createHandler(
+                            (inputs: string[]) => ({
+                                [results]: inputs.map(text => text.length + 1),
+                            })
+                        );
+                        expect(action.get(createItems(stringLengthHandler))).toBe(18);
+                    });
+                    it("Works without sources if returning 1 value", () => {
+                        const stringLengthHandler = action.createHandler(
+                            (inputs: string[]) => ({
+                                [results]: [
+                                    inputs.reduce((cur, text) => cur + text.length, 0) +
+                                        1,
+                                ],
+                            })
+                        );
+                        expect(action.get(createItems(stringLengthHandler))).toBe(16);
+                    });
+                    it("Errors without sources if returning a random number of results", () => {
+                        const stringLengthHandler = action.createHandler(
+                            (inputs: string[]) => ({
+                                [results]: [
+                                    inputs.reduce((cur, text) => cur + text.length, 0) +
+                                        1,
+                                    inputs.reduce((cur, text) => cur + text.length, 0),
+                                ],
+                            })
+                        );
+                        expect(() =>
+                            action.get(createItems(stringLengthHandler))
+                        ).toThrow();
+                    });
+                    it("Can return an arbitrary number of results if the correct number of sources is provided", () => {
+                        const stringLengthHandler = action.createHandler(
+                            (inputs: string[], items) => ({
+                                [results]: [
+                                    inputs.reduce((cur, text) => cur + text.length, 0) +
+                                        1,
+                                    inputs.reduce((cur, text) => cur + text.length, 0),
+                                ],
+                                [sources]: [items.flat(), items.flat()],
+                            })
+                        );
+                        expect(action.get(createItems(stringLengthHandler))).toBe(29);
+                    });
+                    it("Errors if the wrong number of sources is provided", () => {
+                        const stringLengthHandler = action.createHandler(
+                            (inputs: string[], items) => ({
+                                [results]: [
+                                    inputs.reduce((cur, text) => cur + text.length, 0) +
+                                        1,
+                                    inputs.reduce((cur, text) => cur + text.length, 0),
+                                ],
+                                [sources]: items,
+                            })
+                        );
+                        expect(() =>
+                            action.get(createItems(stringLengthHandler))
+                        ).toThrow();
+                    });
+                });
             });
         });
         it("Correctly works for handlers directly", () => {

--- a/app/src/menus/actions/_types/IAction.ts
+++ b/app/src/menus/actions/_types/IAction.ts
@@ -2,6 +2,7 @@ import {ITagsOverride} from "./ITagsOverride";
 import {IActionCore} from "./IActionCore";
 import {IMenuItem} from "../../items/_types/IMenuItem";
 import {IActionBinding} from "./IActionBinding";
+import {IActionMultiResult} from "./IActionMultiResult";
 
 export type IAction<I, O> = {
     /**
@@ -15,10 +16,10 @@ export type IAction<I, O> = {
      * @param defaultTags The default tags that bindings of these handlers should have, this action's default tags are inherited if left out
      * @returns The created action handler
      */
-    createHandler<T>(
-        handlerCore: IActionCore<T, I>,
+    createHandler<T, O extends AI | IActionMultiResult<AI>, AI extends I>(
+        handlerCore: IActionCore<T, O>,
         defaultTags?: ITagsOverride
-    ): IAction<T, I>;
+    ): IAction<T, O>;
 
     /**
      * Creates a binding for this action

--- a/app/src/menus/actions/_types/IActionCore.ts
+++ b/app/src/menus/actions/_types/IActionCore.ts
@@ -1,4 +1,5 @@
 import {IMenuItem} from "../../items/_types/IMenuItem";
+import {results} from "../Action";
 
 /**
  * The core transformer of an action

--- a/app/src/menus/actions/_types/IActionMultiResult.ts
+++ b/app/src/menus/actions/_types/IActionMultiResult.ts
@@ -1,0 +1,15 @@
+import {IMenuItem} from "../../items/_types/IMenuItem";
+import {results, sources} from "../Action";
+
+/**
+ * A format to make action handlers return multiple responses
+ */
+export type IActionMultiResult<O> = {
+    /** The results of the handler */
+    [results]: O[];
+    /**
+     * Optional sources that the data originates from.
+     * This data can be left out if there is only 1 result, or as many results as there were inputs, in other cases it should be provided.
+     */
+    [sources]?: IMenuItem[][];
+};

--- a/app/src/menus/actions/_types/IActionParent.ts
+++ b/app/src/menus/actions/_types/IActionParent.ts
@@ -1,0 +1,9 @@
+import {results} from "../Action";
+import {IAction} from "./IAction";
+
+/**
+ * An acceptable parent action for an action handler with the given output type
+ */
+export type IActionParent<O> = O extends {[results]: (infer U)[]}
+    ? IAction<U, any>
+    : IAction<O, any>;


### PR DESCRIPTION
Made action handlers able to act as mappers instead of only reducers. Moreover, the format is generalized, such that any number of results may be returend. There are 2 ways of defining handlers now.

normal common reducer:
```ts
const handler = action.createHandler(
    (inputs: string[]) => inputs.reduce((cur, text) => cur + text.length + 1, 0),
);
```

multi result mapper:
```ts
const handler = action.createHandler(
    (inputs: string[]) => ({
        [results]: inputs.map(text => text.length + 1),
    })
);
```

And in case that you map to an arbitrary amount of items, you will also have to indicate the sources of the results:
```ts
const handler = action.createHandler(
    (inputs: string[], items) => ({
        [results]: [
            inputs.reduce((cur, text) => cur + text.length, 0) +
                1,
            inputs.reduce((cur, text) => cur + text.length, 0),
        ],
        [sources]: [items.flat(), items.flat()],
    })
);
```
