### PR TITLE
Made action results sort according to input order

### DIFF
--- a/app/src/componentTests/MenuViewTest.tsx
+++ b/app/src/componentTests/MenuViewTest.tsx
@@ -57,6 +57,12 @@ const someField8 = createColorMenuItem({
     undoable: true,
     resetable: true,
 });
+const someField9 = createStringMenuItem({
+    init: "oranges",
+    name: "someField 9",
+    undoable: true,
+    resetable: true,
+});
 class SetFieldCmd extends Command {
     protected prev: string | undefined;
     protected text: string;
@@ -350,6 +356,7 @@ menu.addItems([
     someField6,
     someField7,
     someField8,
+    someField9,
     createStandardMenuItem({
         name: "Undo",
         onExecute: () => undoRedo.undo(),

--- a/app/src/menus/actions/_types/IIndexedMenuItem.ts
+++ b/app/src/menus/actions/_types/IIndexedMenuItem.ts
@@ -1,0 +1,9 @@
+import {IMenuItem} from "../../items/_types/IMenuItem";
+
+/**
+ * Menu items together with their index in the input list for an action
+ */
+export type IIndexedMenuItem = {
+    /** The position of the menu item in the list passed to an action */
+    inputIndex: number;
+} & IMenuItem;

--- a/app/src/menus/items/inputs/handlers/boolean/booleanInputExecuteHandler.ts
+++ b/app/src/menus/items/inputs/handlers/boolean/booleanInputExecuteHandler.ts
@@ -3,7 +3,6 @@ import {createStandardMenuItem} from "../../../createStandardMenuItem";
 import {results} from "../../../../actions/Action";
 import {selectFieldExecuteHandler} from "../../../../../textFields/types/selectField/selectFieldExecuteHandler";
 import {ISelectFieldExecuteData} from "../../../../../textFields/types/selectField/_types/ISelectFieldExecuteData";
-import {IActionMultiResult} from "../../../../actions/_types/IActionMultiResult";
 
 /**
  * A simple execute handler for updating boolean fields


### PR DESCRIPTION
Made the action inputs sort in accordance to the input item order. This makes any possible UI execute in a more intuitive order. 
The asymptotic runtime hasn't been altered, but it will have a slight negative impact on performance. 
Overall I am prioritizing flexibility and overall experience with the Action system, so performance is a slightly less important aspect.