### PR TITLE
Added 'disabled' menu item frame prop

### DIFF
--- a/packages/core/src/components/items/MenuItemFrame.tsx
+++ b/packages/core/src/components/items/MenuItemFrame.tsx
@@ -15,6 +15,7 @@ import {mergeStyles} from "../../utils/mergeStyles";
 import Color from "color";
 import {IThemeColor} from "../../styling/theming/_types/IBaseTheme";
 import {useTheme} from "../../styling/theming/ThemeContext";
+import {useIsItemSelectable} from "./useIsItemSelectable";
 
 /**
  * A menu item frame that visualizes selection state and click handler for item execution
@@ -27,6 +28,7 @@ export const MenuItemFrame: FC<IMenuItemFrameProps> = ({
     item,
     children,
     transparent,
+    disabled,
     outerProps,
     innerProps,
     colors,
@@ -58,6 +60,8 @@ export const MenuItemFrame: FC<IMenuItemFrameProps> = ({
         }
     }, [menu, item]);
 
+    const isSelectable = useIsItemSelectable(item);
+    if (disabled == undefined && !transparent) disabled = !isSelectable;
     const {connectBgPrevious, connectBgNext} = transparent
         ? ({} as IConnections)
         : useConnectAdjacent(menu, item);
@@ -85,6 +89,7 @@ export const MenuItemFrame: FC<IMenuItemFrameProps> = ({
             borderRadiusBottomRight={connectBgNext ? undefined : radiusSize}
             borderRadiusTopLeft={connectBgPrevious ? undefined : radiusSize}
             borderRadiusBottomLeft={connectBgNext ? undefined : radiusSize}
+            opacity={disabled ? 0.5 : 1}
             overflow="hidden"
             elevation={transparent ? undefined : "small"}
             zIndex={1}
@@ -97,12 +102,12 @@ export const MenuItemFrame: FC<IMenuItemFrameProps> = ({
                     background={mainBgColor}
                     color={textColor}
                     marginLeft="medium"
-                    cursor={transparent ? "default" : "pointer"}
+                    cursor={transparent || disabled ? "default" : "pointer"}
                     onClick={useCallback(async () => {
                         if (!menu || !item) return;
                         if (menu.getCursor() == item) {
                             executeAction.execute(menu.getContext(), [item], onExecute);
-                        } else if (isItemSelectable(item)) menu.setCursor(item);
+                        } else if (!disabled && isSelectable) menu.setCursor(item);
                     }, [menu, item])}
                     // Open the context menu on right click
                     onContextMenu={onContextMenu}

--- a/packages/core/src/components/items/_types/IMenuItemFrameProps.ts
+++ b/packages/core/src/components/items/_types/IMenuItemFrameProps.ts
@@ -14,6 +14,8 @@ export type IMenuItemFrameProps = {
     item?: IMenuItem;
     /** Whether to make the background transparent */
     transparent?: boolean;
+    /** Whether to make the item appear disabled, defaults to whether the item is not selectable */
+    disabled?: boolean;
     /** Custom color overrides */
     colors?: {
         selection?: IColors;

--- a/packages/core/src/components/items/useIsItemSelectable.ts
+++ b/packages/core/src/components/items/useIsItemSelectable.ts
@@ -1,0 +1,28 @@
+import {useDataHook, proxyHook} from "model-react";
+import {useMemo, useRef} from "react";
+import {isItemSelectable} from "../../menus/items/isItemSelectable";
+import {IMenuItem} from "../../menus/items/_types/IMenuItem";
+
+/**
+ * A react hook that checks whether a given item is selectable
+ * @param item The menu item to check
+ * @returns Whether the item is selectable
+ */
+export function useIsItemSelectable(item?: IMenuItem): boolean {
+    const [h] = useDataHook();
+    let version = useRef(1);
+    return useMemo(
+        () =>
+            item
+                ? isItemSelectable(
+                      item,
+                      proxyHook(h, {
+                          onCall: () => {
+                              version.current++;
+                          },
+                      })
+                  )
+                : false,
+        [version.current]
+    );
+}

--- a/packages/core/src/menus/items/isItemSelectable.ts
+++ b/packages/core/src/menus/items/isItemSelectable.ts
@@ -1,3 +1,4 @@
+import {IDataHook} from "model-react";
 import {executeAction} from "../../actions/types/execute/executeAction";
 import {hasActionBindingFor} from "../../actions/utils/hasActionBindingFor";
 import {IMenuItem} from "./_types/IMenuItem";
@@ -5,9 +6,10 @@ import {IMenuItem} from "./_types/IMenuItem";
 /**
  * Checks whether a given item can be selected in the menu
  * @param item The item to check
+ * @param hook The hook to subscribe to changes
  * @returns Whether the item is selectable
  * @exportTo ./menus/helpers
  */
-export function isItemSelectable(item: IMenuItem): boolean {
-    return hasActionBindingFor(executeAction, item);
+export function isItemSelectable(item: IMenuItem, hook?: IDataHook): boolean {
+    return hasActionBindingFor(executeAction, item, hook);
 }


### PR DESCRIPTION
Added some styling to the menu item frame such that it's obvious that a menu item can't be selected/executed. 
This styling is only used if `disabled` is set, and `disabled`'s value defaults to whether the menu item is not selectable. 