### PR TITLE
Added UI close handler for fields and content

### DIFF
--- a/packages/core-applets/window-manager/src/position/setupPositionSettingSyncer.tsx
+++ b/packages/core-applets/window-manager/src/position/setupPositionSettingSyncer.tsx
@@ -14,22 +14,22 @@ export function setupPositionSettingSyncer(
     window: BrowserWindow
 ): () => void {
     // Sync the setting to the position
-    let timeoutID: number | undefined;
     const observer = new Observer(h =>
         settingsManager.getSettingsContext(h).get(settings).position.get(h)
     ).listen(({x, y}) => {
-        clearTimeout(timeoutID);
-        timeoutID = setTimeout(() => {
-            const [pX, pY] = window.getPosition();
-            if (pX != x || pY != y) window.setPosition(x, y);
-        }, 100) as any;
+        const [pX, pY] = window.getPosition();
+        if (pX != x || pY != y) window.setPosition(x, y);
     }, true);
 
     // Sync the position to the setting
+    let timeoutID: number | undefined;
     const positionListener = () => {
         const [x, y] = window.getPosition();
-        const field = settingsManager.getSettingsContext().get(settings).position;
-        field.set({x, y});
+        clearTimeout(timeoutID);
+        timeoutID = setTimeout(() => {
+            const field = settingsManager.getSettingsContext().get(settings).position;
+            field.set({x, y});
+        }, 100) as any;
     };
     window.on("move", positionListener);
 

--- a/packages/core-applets/window-manager/src/visibility/setupVisibilityControls.tsx
+++ b/packages/core-applets/window-manager/src/visibility/setupVisibilityControls.tsx
@@ -27,7 +27,10 @@ export function setupVisibilityControls(
             document.body.classList.add("noTransition");
             setTimeout(() => {
                 document.body.style.visibility = "inherit";
-                document.body.classList.remove("noTransition");
+                document.body.className = document.body.className.replace(
+                    /\bnoTransition\b/g,
+                    ""
+                );
             }, 50);
 
             window.show();
@@ -45,6 +48,7 @@ export function setupVisibilityControls(
             returnFocus();
         }
     });
+    if (!LM.isWindowOpen()) document.body.classList.add("noTransition");
     const hideWindow = () => LM.setWindowOpen(false);
     const showWindow = () => LM.setWindowOpen(true);
 

--- a/packages/core/src/content/interaction/keyHandler/createStandardContentKeyHandler.ts
+++ b/packages/core/src/content/interaction/keyHandler/createStandardContentKeyHandler.ts
@@ -8,12 +8,20 @@ import {handleContentScrollInput} from "./handleContentScrollInput";
  * Creates a standard content key handler
  * @param content The content to be handled
  * @param context The context that the handler is used in
+ * @param config Additional configuration
  * @returns The key handler tha can be added to the UILayer
  */
 export function createStandardContentKeyHandler(
     content: IContent,
-    context: IIOContext
+    context: IIOContext,
+    {
+        onExit,
+    }: {
+        /** The code to execute when trying to exit the field */
+        onExit?: () => void;
+    } = {}
 ): IKeyEventListener {
+    const settings = context.settings.get(baseSettings).controls;
     const controlsSettings = context.settings.get(baseSettings).controls.content;
     const generalSettings = context.settings.get(baseSettings).content;
 
@@ -27,5 +35,11 @@ export function createStandardContentKeyHandler(
             )
         )
             return true;
+
+        // Handle exit
+        if (onExit && settings.common.back.get().matches(e)) {
+            onExit();
+            return true;
+        }
     };
 }

--- a/packages/core/src/textFields/interaction/keyHandler/createStandardTextFieldKeyHandler.ts
+++ b/packages/core/src/textFields/interaction/keyHandler/createStandardTextFieldKeyHandler.ts
@@ -17,6 +17,7 @@ import {mergeKeyListeners} from "../../../keyHandler/mergeKeyListeners";
  * Creates a standard text field key handler
  * @param textField The text field to create the handler for
  * @param context The context that the handler is used in
+ * @param config Additional configuration
  * @returns The key handler that can be added to the input handler stack
  */
 export function createStandardTextFieldKeyHandler(

--- a/packages/core/src/uiLayers/_types/IUILayerContentData.ts
+++ b/packages/core/src/uiLayers/_types/IUILayerContentData.ts
@@ -15,4 +15,6 @@ export type IUILayerContentData = {
     contentHandler?: IKeyEventListener;
     /** The overlay group to use, making sure that only the bottom view with the same group in a continuous sequence is shown */
     overlayGroup?: Symbol;
+    /** Whether to prevent the layer from closing when the user uses their back key, defaults to false */
+    handleClose?: boolean;
 };

--- a/packages/core/src/uiLayers/_types/IUILayerFieldData.ts
+++ b/packages/core/src/uiLayers/_types/IUILayerFieldData.ts
@@ -22,4 +22,6 @@ export type IUILayerFieldData = {
     icon?: IThemeIcon | ReactElement;
     /** The overlay group to use, making sure that only the bottom view with the same group in a continuous sequence is shown */
     overlayGroup?: Symbol;
+    /** Whether to prevent the layer from closing when the user uses their back key, defaults to false */
+    handleClose?: boolean;
 };

--- a/packages/core/src/uiLayers/_types/IUILayerMenuData.ts
+++ b/packages/core/src/uiLayers/_types/IUILayerMenuData.ts
@@ -24,4 +24,6 @@ export type IUILayerMenuData = {
     destroyOnClose?: boolean;
     /** The overlay group to use, making sure that only the bottom view with the same group in a continuous sequence is shown */
     overlayGroup?: Symbol;
+    /** Whether to prevent the layer from closing when the user uses their back key, defaults to whether a menu handler is present */
+    handleClose?: boolean;
 };

--- a/packages/core/src/uiLayers/standardUILayer/UILayer.tsx
+++ b/packages/core/src/uiLayers/standardUILayer/UILayer.tsx
@@ -102,7 +102,7 @@ export class UILayer extends UnifiedAbstractUILayer {
             let menuHandler = data.menuHandler;
             if (!menuHandler) {
                 const disposableHandler = createStandardMenuKeyHandler(data.menu, {
-                    onExit: close,
+                    onExit: data.handleClose === false ? undefined : close,
                     onExecute: data.onExecute,
                 });
                 menuHandler = disposableHandler.handler;
@@ -160,7 +160,9 @@ export class UILayer extends UnifiedAbstractUILayer {
                 ),
                 fieldHandler:
                     data.fieldHandler ??
-                    createStandardTextFieldKeyHandler(field, context),
+                    createStandardTextFieldKeyHandler(field, context, {
+                        onExit: !res.menuHandler && data.handleClose ? close : undefined,
+                    }),
                 ...res,
             };
         } else if (data.fieldView) {
@@ -181,7 +183,12 @@ export class UILayer extends UnifiedAbstractUILayer {
                 contentView: data.contentView ?? <ContentView content={content} />,
                 contentHandler:
                     data.contentHandler ??
-                    createStandardContentKeyHandler(content, context),
+                    createStandardContentKeyHandler(content, context, {
+                        onExit:
+                            !res.menuHandler && !res.fieldHandler && data.handleClose
+                                ? close
+                                : undefined,
+                    }),
                 ...res,
             };
         } else if (data.contentView) {


### PR DESCRIPTION
Added a `handleClose` property to `UILayer` config to specify whether to make the back key close the layer. This was handled automatically when a menu controller was created already, without a way to prevent it. Now `handleClose` can explicitly set to false to prevent this, or set to true to also handle it for fields and content.

- Also attempted to fix window animation and positioning problems for the 100th time