### PR TITLE
Fix/Allow negatives in number constraints for settings

### DIFF
--- a/packages/core/src/menus/items/inputs/handlers/number/checkTextNumberConstraints.ts
+++ b/packages/core/src/menus/items/inputs/handlers/number/checkTextNumberConstraints.ts
@@ -12,7 +12,7 @@ export function checkTextNumberConstraints(
     {min, max, increment, baseValue, checkValidity}: INumberConstraints
 ): IInputError | undefined {
     // Make sure the text is numeric
-    if (!/^(\-?\d*\.)?\d+$/.exec(text)) {
+    if (!/^\-?(\d*\.)?\d+$/.exec(text)) {
         const res = /(\-?\d*\.)?\d+/.exec(text);
         return {
             message: "Value must be a number",


### PR DESCRIPTION
Noticed that negative integers weren’t allowed while trying to modify a number setting. Changed position of - sign to correct regex.