### PR TITLE
Feature/Add word deletion with CTRL + Backspace/ Delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,8 @@
 
 ## Non-breaking
 
-...
+### Feature
+
+#### core
+
+-   Added input word deletion support [#154](https://github.com/LaunchMenu/LaunchMenu/pull/154)

--- a/packages/core/src/application/settings/baseSettings/controls/createFieldControlsSettingsFolder.ts
+++ b/packages/core/src/application/settings/baseSettings/controls/createFieldControlsSettingsFolder.ts
@@ -4,10 +4,7 @@ import {createKeyPatternSetting} from "../../../../settings/inputs/createKeyPatt
 import {createSettingsFolder} from "../../../../settings/inputs/createSettingsFolder";
 import {constGetter} from "../../../../utils/constGetter";
 import {cmdModifier} from "../../../../utils/platform/cmdModifier";
-import {
-    wordDeleteModifier,
-    wordJumpModifier,
-} from "../../../../utils/platform/wordJumpModifier";
+import {wordJumpModifier} from "../../../../utils/platform/wordJumpModifier";
 
 /**
  * The categories used for the field folder
@@ -101,7 +98,7 @@ export function createFieldControlsSettingsFolder() {
                 name: "Deletes a word backwards",
                 init: new KeyPattern([
                     {
-                        pattern: `${wordDeleteModifier}+backspace`,
+                        pattern: `${wordJumpModifier}+backspace`,
                         type: "down or repeat",
                         allowExtra: ["shift"],
                     },
@@ -113,7 +110,7 @@ export function createFieldControlsSettingsFolder() {
                 name: "Deletes a word forwards",
                 init: new KeyPattern([
                     {
-                        pattern: `${wordDeleteModifier}+delete`,
+                        pattern: `${wordJumpModifier}+delete`,
                         type: "down or repeat",
                         allowExtra: ["shift"],
                     },

--- a/packages/core/src/application/settings/baseSettings/controls/createFieldControlsSettingsFolder.ts
+++ b/packages/core/src/application/settings/baseSettings/controls/createFieldControlsSettingsFolder.ts
@@ -4,7 +4,10 @@ import {createKeyPatternSetting} from "../../../../settings/inputs/createKeyPatt
 import {createSettingsFolder} from "../../../../settings/inputs/createSettingsFolder";
 import {constGetter} from "../../../../utils/constGetter";
 import {cmdModifier} from "../../../../utils/platform/cmdModifier";
-import {wordJumpModifier} from "../../../../utils/platform/wordJumpModifier";
+import {
+    wordDeleteModifier,
+    wordJumpModifier,
+} from "../../../../utils/platform/wordJumpModifier";
 
 /**
  * The categories used for the field folder
@@ -91,6 +94,32 @@ export function createFieldControlsSettingsFolder() {
                 ]),
                 category: getFieldControlsFolderCategories().jumps,
                 tags: ["text", "input", "caret", "cursor"],
+            }),
+
+            // Word deletion
+            backwardsDeleteWord: createKeyPatternSetting({
+                name: "Deletes a word backwards",
+                init: new KeyPattern([
+                    {
+                        pattern: `${wordDeleteModifier}+backspace`,
+                        type: "down or repeat",
+                        allowExtra: ["shift"],
+                    },
+                ]),
+                category: getFieldControlsFolderCategories().insertDelete,
+                tags: ["text", "input", "delete"],
+            }),
+            forwardsDeleteWord: createKeyPatternSetting({
+                name: "Deletes a word forwards",
+                init: new KeyPattern([
+                    {
+                        pattern: `${wordDeleteModifier}+delete`,
+                        type: "down or repeat",
+                        allowExtra: ["shift"],
+                    },
+                ]),
+                category: getFieldControlsFolderCategories().insertDelete,
+                tags: ["text", "input", "delete"],
             }),
 
             // Text navigation

--- a/packages/core/src/textFields/interaction/commands/RemoveWordCommand.ts
+++ b/packages/core/src/textFields/interaction/commands/RemoveWordCommand.ts
@@ -1,0 +1,78 @@
+import {ITextField} from "../../_types/ITextField";
+import {retrieveArgument} from "./retrieveArgument";
+import {TextEditCommand} from "./TextEditCommand";
+import {IRetrievableArgument} from "./_types/IRetrievableArgument";
+import {ITextAlterationInput} from "./_types/ITextAlterationInput";
+
+/** A command to remove a word at the caret */
+export class RemoveWordCommand extends TextEditCommand {
+    /**
+     * Creates a new command to remove a word from the text field in the given direction
+     * @param targetField The text field to remove the text from
+     * @param direction The direction to remove the word (-1 == backwards)
+     */
+    public constructor(
+        textField: ITextField,
+        direction: IRetrievableArgument<number> = -1
+    ) {
+        super(textField, ({selection}) => {
+            direction = retrieveArgument(direction);
+            const start = Math.min(selection.start, selection.end);
+            const end = Math.max(selection.start, selection.end);
+
+            let newCaretPos = start;
+            let alteration: ITextAlterationInput;
+
+            // If text is currently selected, ignore the direction and just remove it
+            if (start != end) alteration = {start, end, content: ""};
+            // If the direction is backwards remove before the cursor till whitespace and move the cursor backwards
+            else if (direction < 0) {
+                let startIndex = this.backwardsSearchString(textField.get(), start);
+                alteration = {start: startIndex, end, content: ""};
+                newCaretPos = startIndex;
+            }
+            // If the direction is forwards remove after the cursor till whitespace
+            else {
+                let endIndex = this.forwardsSearchString(textField.get(), start);
+                endIndex = endIndex >= 0 ? endIndex : textField.get().length;
+                alteration = {start: start, end: endIndex, content: ""};
+            }
+
+            // Return the new changes and new selection
+            return {text: alteration, selection: {start: newCaretPos, end: newCaretPos}};
+        });
+    }
+
+    /**
+     * Backwards searches the string for the position next word including all spaces around it
+     * @param text The text to search in
+     * @param startIndex The start index from where the search will start
+     * @returns The end index
+     */
+    private backwardsSearchString(text: string, startIndex: number): number {
+        text = text.split("").reverse().join("");
+        var reversedStartIndex = text.length - startIndex;
+        var endIndex = this.forwardsSearchString(text, reversedStartIndex);
+        if (endIndex < 0) return -1;
+
+        return text.length - endIndex;
+    }
+
+    /**
+     * Forward searches the string for the position next word including all spaces around it
+     * @param text The text to search in
+     * @param startIndex The start index from where the search will start
+     * @returns The end index
+     */
+    private forwardsSearchString(text: string, startIndex: number): number {
+        var searchStartIndex = startIndex + text.substr(startIndex).search(/[^\s]/);
+        var firstSpaceIndex = text.substr(searchStartIndex).search(/\s/);
+        if (firstSpaceIndex < 0) return -1;
+
+        var firstCharAfterSpace =
+            text.substr(searchStartIndex + firstSpaceIndex).search(/[^\s]/) - 1;
+        if (firstCharAfterSpace < 0) return -1;
+
+        return searchStartIndex + firstSpaceIndex + firstCharAfterSpace;
+    }
+}

--- a/packages/core/src/textFields/interaction/commands/RemoveWordCommand.ts
+++ b/packages/core/src/textFields/interaction/commands/RemoveWordCommand.ts
@@ -51,8 +51,8 @@ export class RemoveWordCommand extends TextEditCommand {
      */
     private backwardsSearchString(text: string, startIndex: number): number {
         text = text.split("").reverse().join("");
-        var reversedStartIndex = text.length - startIndex;
-        var endIndex = this.forwardsSearchString(text, reversedStartIndex);
+        let reversedStartIndex = text.length - startIndex;
+        let endIndex = this.forwardsSearchString(text, reversedStartIndex);
         if (endIndex < 0) return -1;
 
         return text.length - endIndex;
@@ -65,11 +65,11 @@ export class RemoveWordCommand extends TextEditCommand {
      * @returns The end index
      */
     private forwardsSearchString(text: string, startIndex: number): number {
-        var searchStartIndex = startIndex + text.substr(startIndex).search(/[^\s]/);
-        var firstSpaceIndex = text.substr(searchStartIndex).search(/\s/);
+        let searchStartIndex = startIndex + text.substr(startIndex).search(/[^\s]/);
+        let firstSpaceIndex = text.substr(searchStartIndex).search(/\s/);
         if (firstSpaceIndex < 0) return -1;
 
-        var firstCharAfterSpace =
+        let firstCharAfterSpace =
             text.substr(searchStartIndex + firstSpaceIndex).search(/[^\s]/) - 1;
         if (firstCharAfterSpace < 0) return -1;
 

--- a/packages/core/src/textFields/interaction/keyHandler/handleRemovalInput.ts
+++ b/packages/core/src/textFields/interaction/keyHandler/handleRemovalInput.ts
@@ -5,6 +5,7 @@ import {KeyPattern} from "../../../keyHandler/KeyPattern";
 import {isFieldControlsSettingsFolder} from "./isFieldControlsSettingsFolder";
 import {ITextEditTarget} from "../_types/ITextEditTarget";
 import {RemoveTextCommand} from "../commands/RemoveTextCommand";
+import {RemoveWordCommand} from "../commands/RemoveWordCommand";
 
 /**
  * Handles text removal inputs
@@ -20,6 +21,8 @@ export function handleRemovalInput(
         | {
               backspace: KeyPattern;
               delete: KeyPattern;
+              backwardsDeleteWord: KeyPattern;
+              forwardsDeleteWord: KeyPattern;
           }
         | TSettingsFromFactory<typeof createFieldControlsSettingsFolder>
 ): void | boolean {
@@ -27,8 +30,18 @@ export function handleRemovalInput(
         patterns = {
             backspace: patterns.backspace.get(),
             delete: patterns.delete.get(),
+            backwardsDeleteWord: patterns.backwardsDeleteWord.get(),
+            forwardsDeleteWord: patterns.forwardsDeleteWord.get(),
         };
 
+    if (patterns.backwardsDeleteWord.matches(event)) {
+        onChange(new RemoveWordCommand(textField, -1));
+        return true;
+    }
+    if (patterns.forwardsDeleteWord.matches(event)) {
+        onChange(new RemoveWordCommand(textField, 1));
+        return true;
+    }
     if (patterns.backspace.matches(event)) {
         onChange(new RemoveTextCommand(textField, -1));
         return true;

--- a/packages/core/src/utils/platform/wordJumpModifier.ts
+++ b/packages/core/src/utils/platform/wordJumpModifier.ts
@@ -2,3 +2,4 @@ import {isPlatform} from "./isPlatform";
 
 /** The modifier to make the arrow keys jump entire words at once */
 export const wordJumpModifier = isPlatform("mac") ? "alt" : "ctrl";
+export const wordDeleteModifier = isPlatform("mac") ? "alt" : "ctrl";

--- a/packages/core/src/utils/platform/wordJumpModifier.ts
+++ b/packages/core/src/utils/platform/wordJumpModifier.ts
@@ -2,4 +2,3 @@ import {isPlatform} from "./isPlatform";
 
 /** The modifier to make the arrow keys jump entire words at once */
 export const wordJumpModifier = isPlatform("mac") ? "alt" : "ctrl";
-export const wordDeleteModifier = isPlatform("mac") ? "alt" : "ctrl";


### PR DESCRIPTION
### Added word deletion in input
Word deletion in the LM input is now support with `CTRL  + Backspace` for backwards deletion and `CTRL + Delete` for forwards deletions. On Mac this should also be supported with `ALT` instead of `CTRL`.

Let me know if I missed something or if anything has to be done differently?

Resolves #147