### PR TITLE
Feature/TextHighlighter to have custom highlighting when default search action not used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@
 
 -   Added input word deletion support [#154](https://github.com/LaunchMenu/LaunchMenu/pull/154)
 -   Fixed syntax highlighting updating [#159](https://github.com/LaunchMenu/LaunchMenu/pull/159)
+-   Added standard item highlighting customization [#160](https://github.com/LaunchMenu/LaunchMenu/pull/160)

--- a/packages/core/src/components/items/MenuItemDescription.tsx
+++ b/packages/core/src/components/items/MenuItemDescription.tsx
@@ -1,0 +1,25 @@
+import React, {Fragment} from "react";
+import {simpleSearchHandler} from "../../actions/types/search/tracedRecursiveSearch/simpleSearch/simpleSearchHandler";
+import {LFC} from "../../_types/LFC";
+import {Truncated} from "../Truncated";
+import {IMenuItemDescriptionProps} from "./_types/IMenuItemDescriptionProps";
+
+/** The standard formatting for a menu item description  */
+export const MenuItemDescription: LFC<IMenuItemDescriptionProps> = ({
+    description,
+    searchPattern,
+    query,
+    TextHighlighter = simpleSearchHandler.Highlighter,
+}) => (
+    <Fragment>
+        <Truncated title={description}>
+            {TextHighlighter ? (
+                <TextHighlighter query={query} pattern={searchPattern}>
+                    {description}
+                </TextHighlighter>
+            ) : (
+                description
+            )}
+        </Truncated>
+    </Fragment>
+);

--- a/packages/core/src/components/items/MenuItemName.tsx
+++ b/packages/core/src/components/items/MenuItemName.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import {useDataHook} from "model-react";
+import {simpleSearchHandler} from "../../actions/types/search/tracedRecursiveSearch/simpleSearch/simpleSearchHandler";
+import {Box} from "../../styling/box/Box";
+import {getHooked} from "../../utils/subscribables/getHooked";
+import {LFC} from "../../_types/LFC";
+import {IMenuItemNameProps} from "./_types/IMenuItemNameProps";
+
+/** The standard formatting for a menu item name  */
+export const MenuItemName: LFC<IMenuItemNameProps> = ({
+    name,
+    searchPattern,
+    query,
+    TextHighlighter = simpleSearchHandler.Highlighter,
+}) => {
+    const [h] = useDataHook();
+    const nameV = getHooked(name, h);
+
+    return (
+        <Box font="header">
+            {TextHighlighter ? (
+                <TextHighlighter query={query} pattern={searchPattern}>
+                    {nameV}
+                </TextHighlighter>
+            ) : (
+                nameV
+            )}
+        </Box>
+    );
+};

--- a/packages/core/src/components/items/_types/IMenuItemDescriptionProps.ts
+++ b/packages/core/src/components/items/_types/IMenuItemDescriptionProps.ts
@@ -1,0 +1,16 @@
+import {ISearchHighlighterProps} from "../../../actions/types/search/_types/ISearchHighlighterProps";
+import {ISimpleSearchPatternMatcher} from "../../../actions/types/search/_types/ISimpleSearchPatternMatcher";
+import {IQuery} from "../../../menus/menu/_types/IQuery";
+import {LFC} from "../../../_types/LFC";
+
+/** The props for the standard menu item description */
+export type IMenuItemDescriptionProps = {
+    /** The textual string to show */
+    description: string;
+    /** The pattern matcher to use to extract the text to highlight from the query (E.g. removes prefix) */
+    searchPattern?: ISimpleSearchPatternMatcher;
+    /** The query to highlight in the description */
+    query?: IQuery | null;
+    /** The text highlighter to use for the highlighting, or null to not highlight, defaults to the simple highlighter */
+    TextHighlighter?: LFC<ISearchHighlighterProps> | null;
+};

--- a/packages/core/src/components/items/_types/IMenuItemNameProps.ts
+++ b/packages/core/src/components/items/_types/IMenuItemNameProps.ts
@@ -1,0 +1,17 @@
+import {ISearchHighlighterProps} from "../../../actions/types/search/_types/ISearchHighlighterProps";
+import {ISimpleSearchPatternMatcher} from "../../../actions/types/search/_types/ISimpleSearchPatternMatcher";
+import {IQuery} from "../../../menus/menu/_types/IQuery";
+import {ISubscribable} from "../../../utils/subscribables/_types/ISubscribable";
+import {LFC} from "../../../_types/LFC";
+
+/** The props for the standard menu item name */
+export type IMenuItemNameProps = {
+    /** The textual string to show */
+    name: ISubscribable<string>;
+    /** The pattern matcher to use to extract the text to highlight from the query (E.g. removes prefix) */
+    searchPattern?: ISimpleSearchPatternMatcher;
+    /** The query to highlight in the description */
+    query?: IQuery | null;
+    /** The text highlighter to use for the highlighting, or null to not highlight, defaults to the simple highlighter */
+    TextHighlighter?: LFC<ISearchHighlighterProps> | null;
+};

--- a/packages/core/src/menus/items/_types/IStandardMenuItemData.ts
+++ b/packages/core/src/menus/items/_types/IStandardMenuItemData.ts
@@ -1,6 +1,8 @@
 import {IDataHook} from "model-react";
 import {ReactElement} from "react";
+import {ISearchHighlighterProps} from "../../../actions/types/search/_types/ISearchHighlighterProps";
 import {IThemeIcon} from "../../../styling/theming/_types/IBaseTheme";
+import {LFC} from "../../../_types/LFC";
 import {IStandardActionBindingData} from "./IStandardActionBindingData";
 
 /**
@@ -12,4 +14,6 @@ export type IStandardMenuItemData = IStandardActionBindingData & {
         | IThemeIcon
         | ReactElement
         | ((h?: IDataHook) => IThemeIcon | ReactElement | undefined);
+    /** The text-highlighter used to highlight parts of the name/description when this item is found with a search, or null to skip highlighting */
+    TextHighlighter?: LFC<ISearchHighlighterProps> | null;
 };

--- a/packages/core/src/menus/items/createStandardMenuItem.tsx
+++ b/packages/core/src/menus/items/createStandardMenuItem.tsx
@@ -2,15 +2,14 @@ import React, {memo} from "react";
 import {IMenuItem} from "./_types/IMenuItem";
 import {IStandardMenuItemData} from "./_types/IStandardMenuItemData";
 import {MenuItemFrame} from "../../components/items/MenuItemFrame";
-import {Truncated} from "../../components/Truncated";
 import {MenuItemLayout} from "../../components/items/MenuItemLayout";
 import {MenuItemIcon} from "../../components/items/MenuItemIcon";
 import {getHooked} from "../../utils/subscribables/getHooked";
-import {Box} from "../../styling/box/Box";
 import {createStandardActionBindings} from "./createStandardActionBindings";
 import {ShortcutLabel} from "../../components/items/ShortcutLabel";
-import {simpleSearchHandler} from "../../actions/types/search/tracedRecursiveSearch/simpleSearch/simpleSearchHandler";
 import {useDataHook} from "model-react";
+import {MenuItemDescription} from "../../components/items/MenuItemDescription";
+import {MenuItemName} from "../../components/items/MenuItemName";
 
 /**
  * Creates a new standard menu item
@@ -19,6 +18,7 @@ import {useDataHook} from "model-react";
  */
 export function createStandardMenuItem({
     icon,
+    TextHighlighter,
     ...bindingData
 }: IStandardMenuItemData): IMenuItem {
     const {name, description, shortcut} = bindingData;
@@ -29,30 +29,27 @@ export function createStandardMenuItem({
             const [h] = useDataHook();
             const iconV = getHooked(icon, h);
             const descriptionV = getHooked(description, h);
-            const nameV = getHooked(name, h);
             return (
                 <MenuItemFrame {...props}>
                     <MenuItemLayout
                         icon={iconV && <MenuItemIcon icon={iconV} />}
                         name={
-                            <Box font="header">
-                                <simpleSearchHandler.Highlighter
-                                    query={highlight}
-                                    pattern={bindingData.searchPattern}>
-                                    {nameV}
-                                </simpleSearchHandler.Highlighter>
-                            </Box>
+                            <MenuItemName
+                                name={name}
+                                searchPattern={bindingData.searchPattern}
+                                query={highlight}
+                                TextHighlighter={TextHighlighter}
+                            />
                         }
                         shortcut={shortcut && <ShortcutLabel shortcut={shortcut} />}
                         description={
                             descriptionV && (
-                                <Truncated title={descriptionV}>
-                                    <simpleSearchHandler.Highlighter
-                                        query={highlight}
-                                        pattern={bindingData.searchPattern}>
-                                        {descriptionV}
-                                    </simpleSearchHandler.Highlighter>
-                                </Truncated>
+                                <MenuItemDescription
+                                    description={descriptionV}
+                                    searchPattern={bindingData.searchPattern}
+                                    query={highlight}
+                                    TextHighlighter={TextHighlighter}
+                                />
                             )
                         }
                     />


### PR DESCRIPTION
Added a `TextHighlighter` optional parameter for the `createStandardMenuItem` function.
This allows for customisation of what's highlighted in the item results, which is useful when the default search action isn't used.